### PR TITLE
Update rolling devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -92,7 +92,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: rolling
     last_version: 0.2.0
     name: tango_icons_vendor
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for rolling to match the source branch as specified in https://github.com/ros/rosdistro/rolling/distribution.yaml .
