### PR TITLE
Update Galactic and Foxy devel branches

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -14,7 +14,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: humble
     last_version: 0.1.0
     name: tango_icons_vendor
     patches: null
@@ -40,7 +40,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: humble
     last_version: 0.1.1
     name: tango_icons_vendor
     patches: null

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -14,7 +14,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: humble
+    devel_branch: foxy
     last_version: 0.1.0
     name: tango_icons_vendor
     patches: null
@@ -40,7 +40,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: humble
+    devel_branch: galactic
     last_version: 0.1.1
     name: tango_icons_vendor
     patches: null


### PR DESCRIPTION
The current release for Galactic is associated with the humble branch. I also think it's fine to make the same release for Foxy.
